### PR TITLE
Improve NI LabVIEW (Linux) example: auto-source display env on startup + test.sh helper

### DIFF
--- a/examples/ni_labview_official_container_with_vipm/Dockerfile
+++ b/examples/ni_labview_official_container_with_vipm/Dockerfile
@@ -1,18 +1,35 @@
-FROM nationalinstruments/labview:2025q3patch1-linux
+FROM nationalinstruments/labview:2026q1-linux
 
-# Install VIPM
+ARG VIPM_RELEASE_TYPE=preview
+ARG VIPM_VERSION=26.3.0-3859
+
+
+# wget is required to download VIPM, and is not included in the base LabVIEW image.
 RUN apt-get update \
   && apt-get install -y wget \
   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /usr/local/jki/vipm /etc/jki \
-    && touch /usr/local/jki/vipm/Settings.ini /etc/jki/jki.conf
+# Install VIPM
+RUN wget -O /tmp/vipm.deb \
+    https://packages.jki.net/vipm/${VIPM_RELEASE_TYPE}/vipm_${VIPM_VERSION}_amd64.deb \
+    && dpkg -i /tmp/vipm.deb \
+    && rm /tmp/vipm.deb
 
 RUN wget -O /tmp/vipm.deb \
     https://packages.jki.net/vipm/preview/vipm_latest_preview_amd64.deb \
     && dpkg -i /tmp/vipm.deb \
     && rm /tmp/vipm.deb
 
+
+WORKDIR /root
+
+COPY docker-display.sh /usr/local/jki/vipm/support/docker-display.sh
+RUN chmod +x /usr/local/jki/vipm/support/docker-display.sh
+
+COPY docker-entrypoint.sh /usr/local/jki/vipm/support/docker-entrypoint.sh
+RUN chmod +x /usr/local/jki/vipm/support/docker-entrypoint.sh
+    
 RUN vipm help
 
+ENTRYPOINT [ "/usr/local/jki/vipm/support/docker-entrypoint.sh" ]
 CMD [ "bash" ]

--- a/examples/ni_labview_official_container_with_vipm/README.md
+++ b/examples/ni_labview_official_container_with_vipm/README.md
@@ -14,6 +14,7 @@ You can find more information about NI's official container image, as well as so
 - `.env.example` is a template file you will populate and save as `.env` which contains the environment variables that will be used by your running container.
 - `docker-compose.yml` is a `docker compose` file that adds a little bit of structure to your docker configuration.
 - `Dockerfile` the specific commands (and base/starting container) for building your container.
+- `test.sh` a convenience script that builds the image and drops you into an interactive shell inside a fresh container.
 
 ### Create a .env file with your VIPM Pro serial number information.
 
@@ -35,6 +36,10 @@ VIPM_EMAIL=your.email@example.com
 Run the following command on your host computer, to build and then run your container, opening a bash shell within the container:
 
 `docker compose run --rm vipm-labview`
+
+Alternatively, run the `test.sh` script, which builds the image and drops you into an interactive shell inside a fresh container:
+
+`./test.sh`
 
 ## Using VIPM (to install packages in LabVIEW) from inside the running container
 

--- a/examples/ni_labview_official_container_with_vipm/docker-display.sh
+++ b/examples/ni_labview_official_container_with_vipm/docker-display.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Bootstrap a headless X display + LabVIEW container marker so the
+# LabVIEW Runtime Engine (used by `vipm install` and vipm-desktop)
+# can initialize inside this Docker container.
+#
+# The X server always lives on display :99. DISPLAY handling:
+#   - If DISPLAY is already :99 (e.g. Dockerfile `ENV DISPLAY=:99` or
+#     `docker run -e DISPLAY=:99`), nothing is exported and the script is
+#     safe to run either sourced or as a subprocess.
+#   - If DISPLAY is unset or points elsewhere, the script exports
+#     DISPLAY=:99 ? which only persists in your shell when sourced:
+#
+#       source ./bootstrap-display.sh    # or:  . ./bootstrap-display.sh
+#
+#     A conflicting non-:99 value is overridden, with a warning.
+#
+# Safe to invoke multiple times ? skips Xvfb if one is already running.
+
+# `set -e` is a shell option, so sourcing this script would otherwise leak
+# `errexit` into the caller's interactive shell. Capture the caller's
+# setting now and restore it on the way out.
+_saved_errexit=$(set +o | grep errexit)
+set -e
+
+# This container's headless X server always lives on :99, and the rest of
+# the LabVIEW container tooling assumes it. TARGET_DISPLAY is the single
+# source of truth for both the Xvfb server and the exported DISPLAY.
+readonly TARGET_DISPLAY=":99"
+
+# A pre-set DISPLAY pointing somewhere other than :99 conflicts with the
+# server this script starts. Flag it loudly; it is overridden below.
+if [ -n "${DISPLAY:-}" ] && [ "$DISPLAY" != "$TARGET_DISPLAY" ]; then
+    echo "WARNING: DISPLAY=$DISPLAY conflicts with this container's X server," >&2
+    echo "         which always runs on $TARGET_DISPLAY ? overriding to $TARGET_DISPLAY." >&2
+fi
+
+# Ensure DISPLAY ends up as :99. If it is already correct there is nothing
+# to export and the script is safe to run sourced or as a subprocess.
+# Otherwise it must export ? which only reaches the calling shell when the
+# script is sourced, since a subprocess cannot mutate its parent's env.
+if [ "${DISPLAY:-}" != "$TARGET_DISPLAY" ]; then
+    # `return` only succeeds in a sourced script; the subshell keeps the
+    # failure non-fatal under `set -e`.
+    if ! (return 0 2>/dev/null); then
+        script_path="${BASH_SOURCE:-$0}"
+        echo "ERROR: DISPLAY is not $TARGET_DISPLAY and $script_path was run as a" >&2
+        echo "       subprocess, so it cannot export DISPLAY into your shell. Either:" >&2
+        echo >&2
+        echo "         source $script_path    # export DISPLAY into this shell" >&2
+        echo >&2
+        echo "       or set DISPLAY=$TARGET_DISPLAY in the container before invoking it" >&2
+        echo "       (Dockerfile 'ENV DISPLAY=$TARGET_DISPLAY' or 'docker run -e DISPLAY=$TARGET_DISPLAY')." >&2
+        exit 1
+    fi
+
+    export DISPLAY="$TARGET_DISPLAY"
+fi
+
+
+# /usr/local/natinst/LabVIEW-2026-64/labviewprofull &
+
+# Start Xvfb if it is not already running. If it is already running, assume it is correctly configured for this container and do nothing.
+if ! pgrep -x Xvfb > /dev/null; then
+    Xvfb "$TARGET_DISPLAY" -screen 0 1280x720x24 -ac +extension GLX +render -noreset \
+        > /tmp/xvfb.log 2>&1 &
+fi
+# Writing this marker file is critical and if if it is not present, the LabVIEW Runtime Engine (required by vipm) may not start properly.
+mkdir -p /tmp/natinst && echo "1" > /tmp/natinst/LVContainer.txt
+# Start Xvfb before the LabVIEW Runtime Engine initializes, which happens on the first `vipm` command.
+echo "$(pgrep -x Xvfb > /dev/null && echo "Xvfb running (DISPLAY=$TARGET_DISPLAY)" || echo "WARNING: Xvfb is required by vipm, but failed to start; DISPLAY=$DISPLAY may not work. Check /tmp/xvfb.log for details.")"
+
+# Restore the caller's errexit setting (only observable when sourced).
+eval "$_saved_errexit"
+unset _saved_errexit

--- a/examples/ni_labview_official_container_with_vipm/docker-entrypoint.sh
+++ b/examples/ni_labview_official_container_with_vipm/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Source the VIPM/LabVIEW environment bootstrap so the headless X server and
+# Runtime Engine markers are in place before any command runs, then hand off
+# to the container's command (CMD or `docker run` arguments).
+source /usr/local/jki/vipm/support/docker-display.sh
+
+exec "$@"

--- a/examples/ni_labview_official_container_with_vipm/test.sh
+++ b/examples/ni_labview_official_container_with_vipm/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build the LabVIEW + VIPM image and drop into an interactive shell inside a
+# fresh container. The entrypoint sources docker-display.sh on the way in, so
+# the headless X server and Runtime Engine markers are ready before the prompt
+# appears.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+IMAGE="${IMAGE:-ni-labview-vipm:test}"
+
+docker build -t "$IMAGE" .
+
+docker run --rm -it "$IMAGE"


### PR DESCRIPTION
## Summary

Improvements to the `ni_labview_official_container_with_vipm` (Linux) example, split out from the Windows example branch so they stand on their own.

- **Auto-source the display/env bootstrap on container start.** A new `docker-entrypoint.sh` sources `docker-display.sh` (headless Xvfb on `:99` + LabVIEW Runtime Engine markers) before running the container command, then `exec "$@"`. This applies to both interactive `bash` and one-off `docker run <image> <cmd>` invocations, so `vipm install` has a working display without any manual `source` step.
- **Add `test.sh`** — builds the image and drops you into an interactive shell in a fresh container (`docker build` + `docker run --rm -it`). Documented in the README.

## Changes

- `Dockerfile`
  - Bump base image to `nationalinstruments/labview:2026q1-linux`.
  - Parameterize the VIPM download via `ARG VIPM_RELEASE_TYPE` / `ARG VIPM_VERSION`.
  - Install VIPM from the `.deb` package; drop the old `mkdir`/`touch` stub.
  - Copy `docker-display.sh` and `docker-entrypoint.sh` into the image, make them executable, and set `ENTRYPOINT` (keeping `CMD ["bash"]`).
- `docker-entrypoint.sh` (new) — sources `docker-display.sh`, then `exec "$@"`.
- `docker-display.sh` (new) — headless X server + Runtime Engine setup; safe to source repeatedly.
- `test.sh` (new) — build + interactive run helper.
- `README.md` — document `test.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)